### PR TITLE
Migrate ActivityGuardExtension to using Gradle lazy properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ plugins {
 }
 //以下均为非必须
 actGuard {
-    //是否开启
-    isEnable = true
+    //是否开启，默认值 true
+    enable.set(true)
     //不需要混淆的类
     whiteClassList = hashSetOf(
         "com.activityGuard.confuseapp.MainActivity1",

--- a/plugin/src/main/kotlin/ObfuscatorBundleResTask.kt
+++ b/plugin/src/main/kotlin/ObfuscatorBundleResTask.kt
@@ -48,7 +48,7 @@ abstract class ObfuscatorBundleResTask : DefaultTask() {
 
 
     private val actGuard: ActivityGuardExtension by lazy {
-        project.extensions.getByType(ActivityGuardExtension::class.java) ?: ActivityGuardExtension()
+        project.extensions.getByType(ActivityGuardExtension::class.java)
     }
 
     @TaskAction
@@ -307,7 +307,7 @@ abstract class ObfuscatorBundleResTask : DefaultTask() {
 
     //白名单正则表达式
     private val regexPatterns by lazy {
-        actGuard.whiteClassList.map { pattern ->
+        actGuard.whiteClassList.get().map { pattern ->
             pattern
                 .replace("*", ".*") // 将 '*' 替换为 '.*'（匹配零个或多个字符）
                 .replace("?", ".?") // 将 '?' 替换为 '.?'（匹配零个或一个字符）

--- a/plugin/src/main/kotlin/ObfuscatorPlugin.kt
+++ b/plugin/src/main/kotlin/ObfuscatorPlugin.kt
@@ -22,15 +22,14 @@ import java.io.File
  */
 class ObfuscatorPlugin : Plugin<Project> {
     override fun apply(project: Project) {
-        project.extensions.create("actGuard", ActivityGuardExtension::class.java)
+        val actGuard = project.extensions.create("actGuard", ActivityGuardExtension::class.java)
+        actGuard.enable.convention(true)
+
         project.plugins.withType(AppPlugin::class.java) {
             val androidComponents =
                 project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
             androidComponents.onVariants { variant ->
-
-                val actGuard = project.extensions.getByType(ActivityGuardExtension::class.java)
-                    ?: ActivityGuardExtension()
-                if (!actGuard.isEnable) {
+                if (!actGuard.enable.get()) {
                     return@onVariants
                 }
                 val artifacts = variant.artifacts as? ArtifactsImpl ?: return@onVariants

--- a/plugin/src/main/kotlin/model/ActivityGuardExtension.kt
+++ b/plugin/src/main/kotlin/model/ActivityGuardExtension.kt
@@ -1,12 +1,24 @@
 package com.kotlin.model
 
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+
 /**
  * Created by DengLongFei
  * 2024/11/25
  */
-open class ActivityGuardExtension {
-    var isEnable = true
-    var whiteClassList = hashSetOf<String>()
+abstract class ActivityGuardExtension {
+    /**
+     * Whether to enable the main logic.
+     *
+     * Defaults to `true`.
+     */
+    @get:Input
+    abstract val enable: Property<Boolean>
+
+    @get:Input
+    abstract val whiteClassList: SetProperty<String>
 
     //类名混淆
     var obfuscatorClassFunction: ((String, String) -> String)? = null


### PR DESCRIPTION
`obfuscatorClassFunction` 和 `obfuscatorDirFunction` 也应该被迁移，避免直接使用 lambda 的方式，目前的想法是用

```kt
    /**
     * The mapping of the original class names to the obfuscated class names.
     *
     * e.g. `com.example.MyActivity` to `a.b.C`.
     */
    @get:Input
    val classMapping: MapProperty<String, String>

    /**
     * The mapping of the original path to the obfuscated path.
     *
     * e.g. `com.example` to `a.b`.
     */
    @get:Input
    val pathMapping: MapProperty<String, String>
```

替代，或者类似 [SimpleRelocator](https://github.com/GradleUp/shadow/blob/main/src/main/kotlin/com/github/jengelman/gradle/plugins/shadow/relocation/SimpleRelocator.kt) 这样的方案